### PR TITLE
Add interaction between consumer and his callback

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+- 2014-01-28
+    * adds new interface InteractiveConsumerInterface to allow communication between consumer and his callback. at this time, only implements a way to stop consume from callback.
 - 2013-01-18
     *  adds an an optional parameter for the AMQP Message Properties for the publish method of the Producer, so they can be set as well. For example, seeting the application_headers is now possible.
 

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -123,7 +123,7 @@ class OldSoundRabbitMqExtension extends Extension
                 ->addTag('old_sound_rabbit_mq.consumer')
                 ->addMethodCall('setExchangeOptions', array($this->normalizeArgumentKeys($consumer['exchange_options'])))
                 ->addMethodCall('setQueueOptions', array($this->normalizeArgumentKeys($consumer['queue_options'])))
-                ->addMethodCall('setCallback', array(array(new Reference($consumer['callback']), 'execute')));
+                ->addMethodCall('setCallback', array(new Reference($consumer['callback'])));
 
             if (array_key_exists('qos_options', $consumer)) {
                 $definition->addMethodCall('setQosOptions', array(

--- a/RabbitMq/BaseConsumer.php
+++ b/RabbitMq/BaseConsumer.php
@@ -16,7 +16,7 @@ abstract class BaseConsumer extends BaseAmqp
 
     protected $idleTimeout = 0;
 
-    public function setCallback($callback)
+    public function setCallback(ConsumerInterface $callback)
     {
         $this->callback = $callback;
     }

--- a/RabbitMq/Consumer.php
+++ b/RabbitMq/Consumer.php
@@ -60,7 +60,7 @@ class Consumer extends BaseConsumer
     public function processMessage(AMQPMessage $msg)
     {
 
-        $processFlag = call_user_func($this->callback, $msg);
+        $processFlag = $this->callback->execute($msg);
 
         if ($processFlag === ConsumerInterface::MSG_REJECT_REQUEUE || false === $processFlag) {
             // Reject and requeue message to RabbitMQ
@@ -79,7 +79,8 @@ class Consumer extends BaseConsumer
         $this->consumed++;
         $this->maybeStopConsumer();
 
-        if (!is_null($this->getMemoryLimit()) && $this->isRamAlmostOverloaded()) {
+        if ((!is_null($this->getMemoryLimit()) && $this->isRamAlmostOverloaded()) ||
+            ($this->callback instanceof InteractiveConsumerInterface && true === $this->callback->mustStopConsumer())) {
             $this->stopConsuming();
         }
     }

--- a/RabbitMq/InteractiveConsumerInterface.php
+++ b/RabbitMq/InteractiveConsumerInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\RabbitMq;
+
+/**
+ * Interface to add interaction between consumer and his callback.
+ *
+ * @author metfan
+ *
+ */
+interface InteractiveConsumerInterface extends ConsumerInterface
+{
+    /**
+     * Return if consumer must be stoped
+     *
+     * @return boolean
+     */
+    public function mustStopConsumer();
+}

--- a/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
+++ b/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
@@ -174,7 +174,7 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
                 ),
                 array(
                     'setCallback',
-                    array(array(new Reference('foo.callback'), 'execute'))
+                    array(new Reference('foo.callback'))
                 )
             ),
             $definition->getMethodCalls()
@@ -225,7 +225,7 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
                 ),
                 array(
                     'setCallback',
-                    array(array(new Reference('default.callback'), 'execute'))
+                    array(new Reference('default.callback'))
                 )
             ),
             $definition->getMethodCalls()


### PR DESCRIPTION
I'm having some troubles with long time running consumer, I loose MysQL connection and can't reopen it.
In this case I need to requeue my message and stop the consumer to start a fresh one.

The only way I found to stop consumer is to throw an exception but in this case I can't return ConsumerInterface::MSG_SINGLE_NACK_REQUEUE at the end of execute() method in my callback.

In BaseConsumer class there is code to stop consumer and I don't want to inject consumer in my callback (circle reference, not good).

So I propose some change:
- don't inject a callable in BaseConsumer::setCallBack() but the real service and type hint the parameter
- replace use of call_user_func() by calling the execute() method
- extend ConsumerInterface with a new InteractiveConsumerInterface
- test use of InteractiveConsumerInterface at the end Consumer::processMessage() to potentially stop consume