### PR TITLE
RPC Server queue_options

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -196,6 +196,7 @@ class Configuration implements ConfigurationInterface
                     ->canBeUnset()
                     ->useAttributeAsKey('key')
                     ->prototype('array')
+                        ->append($this->getQueueConfiguration())
                         ->children()
                             ->scalarNode('connection')->defaultValue('default')->end()
                             ->scalarNode('callback')->isRequired()->end()

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -330,6 +330,9 @@ class OldSoundRabbitMqExtension extends Extension
                     $server['qos_options']['global']
                 ));
             }
+            if (array_key_exists('queue_options', $server)) {
+                $definition->addMethodCall('setQueueOptions', array($server['queue_options']));
+            }
             $this->container->setDefinition(sprintf('old_sound_rabbit_mq.%s_server', $key), $definition);
         }
     }

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ consumers:
 
 From: http://www.rabbitmq.com/tutorials/tutorial-two-python.html
 
-Be careful as implementing the fair dispatching introduce a latency that will hurt performance (see [this blogpost](http://www.rabbitmq.com/blog/2012/05/11/some-queuing-theory-throughput-latency-and-bandwidth/)). But implemeting it allow you to scale horizontally dynamically as the queue is increasing. 
+Be careful as implementing the fair dispatching introduce a latency that will hurt performance (see [this blogpost](http://www.rabbitmq.com/blog/2012/05/11/some-queuing-theory-throughput-latency-and-bandwidth/)). But implemeting it allow you to scale horizontally dynamically as the queue is increasing.
 You should evaluate, as the blogpost reccommand, the right value of prefetch_size accordingly with the time taken to process each message and your network performance.
 
 With RabbitMqBundle, you can configure that qos_options per consumer like that:
@@ -385,7 +385,10 @@ rpc_servers:
         connection: default
         callback:   random_int_server
         qos_options: {prefetch_size: 0, prefetch_count: 1, global: false}
+        queue_options: {name: random_int_queue, durable: false, auto_delete: true}
 ```
+
+*For a full configuration reference please use the `php app/console config:dump-reference old_sound_rabbit_mq` command.*
 
 Here we have a very useful server: it returns random integers to its clients. The callback used to process the request will be the __random\_int\_server__ service. Now let's see how to invoke it from our controllers.
 

--- a/Tests/DependencyInjection/Fixtures/test.yml
+++ b/Tests/DependencyInjection/Fixtures/test.yml
@@ -148,3 +148,8 @@ old_sound_rabbit_mq:
 
         default_server:
             callback:        default_server.callback
+
+        server_with_queue_options:
+            callback:        server_with_queue_options.callback
+            queue_options:
+                name: "server_with_queue_options-queue"

--- a/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
+++ b/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
@@ -468,6 +468,34 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('%old_sound_rabbit_mq.rpc_server.class%', $definition->getClass());
     }
 
+    public function testRpcServerWithQueueOptionsDefinition()
+    {
+        $container = $this->getContainer('test.yml');
+
+        $this->assertTrue($container->has('old_sound_rabbit_mq.server_with_queue_options_server'));
+        $definition = $container->getDefinition('old_sound_rabbit_mq.server_with_queue_options_server');
+        $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.default');
+        $this->assertEquals((string) $definition->getArgument(1), 'old_sound_rabbit_mq.channel.server_with_queue_options');
+        $this->assertEquals(array(
+                array('initServer', array('server_with_queue_options')),
+                array('setCallback', array(array(new Reference('server_with_queue_options.callback'), 'execute'))),
+                array('setQueueOptions', array(array(
+                    'name'         => 'server_with_queue_options-queue',
+                    'passive'      => false,
+                    'durable'      => true,
+                    'exclusive'    => false,
+                    'auto_delete'  => false,
+                    'nowait'       => false,
+                    'arguments'    => null,
+                    'ticket'       => null,
+                    'routing_keys' => array(),
+                ))),
+            ),
+            $definition->getMethodCalls()
+        );
+        $this->assertEquals('%old_sound_rabbit_mq.rpc_server.class%', $definition->getClass());
+    }
+
     public function testHasCollectorWhenChannelsExist()
     {
         $container = $this->getContainer('collector.yml');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Use case | We need the `routing_keys` option