### PR TITLE
Review Symfony components dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
         - php: hhvm
 
 env:
-    - SYMFONY_VERSION="2.1.*"
-    - SYMFONY_VERSION="2.2.*"
     - SYMFONY_VERSION="2.3.*"
     - SYMFONY_VERSION="2.4.*"
     - SYMFONY_VERSION="2.5.*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - 5.5
   - 5.6
   - hhvm
- 
+
 matrix:
     allow_failures:
         - php: hhvm
@@ -15,6 +15,9 @@ env:
     - SYMFONY_VERSION="2.1.*"
     - SYMFONY_VERSION="2.2.*"
     - SYMFONY_VERSION="2.3.*"
+    - SYMFONY_VERSION="2.4.*"
+    - SYMFONY_VERSION="2.5.*"
+    - SYMFONY_VERSION="2.6.*"
 
 before_script:
     - composer self-update

--- a/Command/BaseRabbitMqCommand.php
+++ b/Command/BaseRabbitMqCommand.php
@@ -2,8 +2,30 @@
 
 namespace OldSound\RabbitMqBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand as Command;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Console\Command\Command;
 
-abstract class BaseRabbitMqCommand extends Command
+abstract class BaseRabbitMqCommand extends Command implements ContainerAwareInterface
 {
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @return ContainerInterface
+     */
+    public function getContainer()
+    {
+        return $this->container;
+    }
 }

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -4,7 +4,7 @@ namespace OldSound\RabbitMqBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This bundle was presented at [Symfony Live Paris 2011](http://www.symfony-live.c
 
 ## Installation ##
 
-### For Symfony >= 2.1.* ###
+### For Symfony Framework >= 2.3 ###
 
 Require the bundle in your composer.json file:
 
@@ -58,40 +58,31 @@ $ composer update oldsound/rabbitmq-bundle
 
 Enjoy !
 
-### For Symfony 2.0.* ###
+### For a console application that uses Symfony Console, Dependency Injection and Config components ###
 
-The following instructions have been tested on a project created with the [Symfony2 Standard 2.0.6](http://symfony.com/download?v=Symfony_Standard_2.0.6.tgz)
+If you have a console application used to run RabbitMQ consumers, you do not need Symfony HttpKernel and FrameworkBundle.
+From version 1.6, you can use the Dependency Injection component to load this bundle configuration and services, and then use the consumer command.
 
-Put the RabbitMqBundle and the [php-amqplib](http://github.com/videlalvaro/php-amqplib) library into the deps file:
+Require the bundle in your composer.json file:
 
-```ini
-[RabbitMqBundle]
-git=http://github.com/videlalvaro/RabbitMqBundle.git
-target=/bundles/OldSound/RabbitMqBundle
-
-[php-amqplib]
-git=http://github.com/videlalvaro/php-amqplib.git
-target=videlalvaro/php-amqplib
-```
-
-Register the bundle and library namespaces in the `app/autoload.php` file:
-
-```php
-$loader->registerNamespaces(array(
-    'OldSound'         => __DIR__.'/../vendor/bundles',
-    'PhpAmqpLib'       => __DIR__.'/../vendor/videlalvaro/php-amqplib',
-));
-```
-
-Add the RabbitMqBundle to your application's kernel:
-
-```php
-public function registerBundles()
+````
 {
-    $bundles = array(
-        new OldSound\RabbitMqBundle\OldSoundRabbitMqBundle(),
-    );
+    "require": {
+        "oldsound/rabbitmq-bundle": "~1.6",
+    }
 }
+```
+
+Register the extension and the compiler pass:
+
+```php
+use OldSound\RabbitMqBundle\DependencyInjection\OldSoundRabbitMqExtension;
+use OldSound\RabbitMqBundle\DependencyInjection\Compiler\RegisterPartsPass;
+
+// ...
+
+$containerBuilder->registerExtension(new OldSoundRabbitMqExtension());
+$containerBuilder->addCompilerPass(new RegisterPartsPass());
 ```
 
 ### Warning - BC Breaking Changes ###
@@ -520,7 +511,7 @@ Be aware that all queues are under the same exchange, it's up to you to set the 
 The `queues_provider` is a optional service that dynamically provides queues.
 It must implement `QueuesProviderInterface`.
 
-Be aware that queues providers are responsible for the proper calls to `setDequeuer` and that callbacks are callables 
+Be aware that queues providers are responsible for the proper calls to `setDequeuer` and that callbacks are callables
 (not `ConsumerInterface`). In case service providing queues implements `DequeuerAwareInterface`, a call to
 `setDequeuer` is added to the definition of the service with a `DequeuerInterface` currently being a `MultipleConsumer`.
 

--- a/Tests/Command/BaseCommandTest.php
+++ b/Tests/Command/BaseCommandTest.php
@@ -11,7 +11,7 @@ abstract class BaseCommandTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->application = $this->getMockBuilder('Symfony\\Bundle\\FrameworkBundle\\Console\\Application')
+        $this->application = $this->getMockBuilder('Symfony\\Component\\Console\\Application')
             ->disableOriginalConstructor()
             ->getMock();
         $this->definition = $this->getMockBuilder('Symfony\\Component\\Console\\Input\\InputDefinition')

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
     }],
     "require": {
         "php"                          : ">=5.3.0",
-        "symfony/dependency-injection" : "~2.1",
-        "symfony/event-dispatcher"     : "~2.1",
-        "symfony/config"               : "~2.1",
-        "symfony/yaml"                 : "~2.1",
-        "symfony/console"              : "~2.1",
+        "symfony/dependency-injection" : "~2.3",
+        "symfony/event-dispatcher"     : "~2.3",
+        "symfony/config"               : "~2.3",
+        "symfony/yaml"                 : "~2.3",
+        "symfony/console"              : "~2.3",
         "videlalvaro/php-amqplib"      : "~2.4.0"
     },
     "suggest": {
@@ -22,7 +22,7 @@
     "require-dev": {
         "symfony/serializer": "~2.3",
         "symfony/debug"     : "~2.3",
-        "phpunit/phpunit"   : ">=3.7.20"
+        "phpunit/phpunit" : ">=3.7.0"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -1,21 +1,28 @@
 {
     "name": "oldsound/rabbitmq-bundle",
     "description": "Integrates php-amqplib with Symfony2 and RabbitMq",
-    "keywords": ["symfony2", "rabbitmq", "message", "queue"],
+    "keywords": ["symfony2", "rabbitmq", "message", "queue", "amqp"],
     "type": "symfony-bundle",
     "license": "MIT",
     "authors": [{
         "name" : "Alvaro Videla"
     }],
     "require": {
-        "php"                      : ">=5.3.0",
-        "symfony/framework-bundle" : "~2.1",
-        "symfony/yaml": "~2.0",
-        "videlalvaro/php-amqplib"  : "~2.4.0"
+        "php"                          : ">=5.3.0",
+        "symfony/dependency-injection" : "~2.1",
+        "symfony/event-dispatcher"     : "~2.1",
+        "symfony/config"               : "~2.1",
+        "symfony/yaml"                 : "~2.1",
+        "symfony/console"              : "~2.1",
+        "videlalvaro/php-amqplib"      : "~2.4.0"
+    },
+    "suggest": {
+        "symfony/framework-bundle" : "To use this lib as a full Symfony Bundle and to use the profiler data collector"
     },
     "require-dev": {
-        "symfony/console": "~2.0",
-        "symfony/serializer": "~2.6"
+        "symfony/serializer": "~2.3",
+        "symfony/debug"     : "~2.3",
+        "phpunit/phpunit"   : ">=3.7.20"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
HttpKernel and FrameworkBundle are not necessary for a simple console application.
This bundle could be used in a console application, with Symfony Console and Dependency Injection components, to run RabbitMQ consumers.

So I changed the dependendies in composer.json from "symfony/framework-bundle" to "symfony/dependency-injection" and other mininum required Symfony components.

I also changed the minimum supported version for Symfony from 2.0 to 2.3 (Symfony < 2.3 is not supported by SensioLabs anymore)