### PR TITLE
add ProducerInterface

### DIFF
--- a/RabbitMq/Fallback.php
+++ b/RabbitMq/Fallback.php
@@ -2,9 +2,9 @@
 
 namespace OldSound\RabbitMqBundle\RabbitMq;
 
-class Fallback
+class Fallback implements ProducerInterface
 {
-    public function publish()
+    public function publish($msgBody, $routingKey = '', $additionalProperties = array())
     {
         return false;
     }

--- a/RabbitMq/Producer.php
+++ b/RabbitMq/Producer.php
@@ -8,7 +8,7 @@ use PhpAmqpLib\Message\AMQPMessage;
 /**
  * Prodcuer, that publishes AMQP Messages
  */
-class Producer extends BaseAmqp
+class Producer extends BaseAmqp implements ProducerInterface
 {
     protected $contentType = 'text/plain';
     protected $deliveryMode = 2;

--- a/RabbitMq/ProducerInterface.php
+++ b/RabbitMq/ProducerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\RabbitMq;
+
+interface ProducerInterface
+{
+    /**
+     * Publish a message
+     *
+     * @param string $msgBody
+     * @param string $routingKey
+     * @param array $additionalProperties
+     */
+    public function publish($msgBody, $routingKey = '', $additionalProperties = array());
+}


### PR DESCRIPTION
In sandbox mode, instead of `Producer`, `old_sound_rabbit_mq.my_name_producer` is mapped on the `Fallback` class.
In this way, if you are typing the producer, you can't use the sandbox mode unless you remove the typing. E.g.

```
class myClass() {
  public function __construct($producer, $message)
}
```

Adding the ProducerInterface you can type the producer and use both `Producer` and `Fallback`:

```
class myClass() {
  public function __construct(ProducerInterface $producer, $message)
}
```
