### PR TITLE
Deprecated: The Definition::setFactoryService method is deprecated since...

### DIFF
--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -82,8 +82,14 @@ class OldSoundRabbitMqExtension extends Extension
             $this->container->setDefinition($factoryName, $definition);
 
             $definition = new Definition($classParam);
-            $definition->setFactoryService($factoryName);
-            $definition->setFactoryMethod('createConnection');
+            if (method_exists($definition, 'setFactory')) {
+                // to be inlined in services.xml when dependency on Symfony DependencyInjection is bumped to 2.6
+                $definition->setFactory(array(new Reference($factoryName), 'createConnection'));
+            } else {
+                // to be removed when dependency on Symfony DependencyInjection is bumped to 2.6
+                $definition->setFactoryService($factoryName);
+                $definition->setFactoryMethod('createConnection');
+            }
 
             $this->container->setDefinition(sprintf('old_sound_rabbit_mq.connection.%s', $key), $definition);
         }

--- a/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
+++ b/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
@@ -19,7 +19,7 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
         $definition = $container->getDefinition('old_sound_rabbit_mq.connection.foo_connection');
         $this->assertTrue($container->has('old_sound_rabbit_mq.connection_factory.foo_connection'));
         $factory = $container->getDefinition('old_sound_rabbit_mq.connection_factory.foo_connection');
-        $this->assertEquals('old_sound_rabbit_mq.connection_factory.foo_connection', $definition->getFactoryService());
+        $this->assertEquals(array('old_sound_rabbit_mq.connection_factory.foo_connection', 'createConnection'), $definition->getFactory());
         $this->assertEquals(array(
             'host' => 'foo_host',
             'port' => 123,
@@ -44,7 +44,7 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
         $definition = $container->getDefinition('old_sound_rabbit_mq.connection.ssl_connection');
         $this->assertTrue($container->has('old_sound_rabbit_mq.connection_factory.ssl_connection'));
         $factory = $container->getDefinition('old_sound_rabbit_mq.connection_factory.ssl_connection');
-        $this->assertEquals('old_sound_rabbit_mq.connection_factory.ssl_connection', $definition->getFactoryService());
+        $this->assertEquals(array('old_sound_rabbit_mq.connection_factory.ssl_connection', 'createConnection'), $definition->getFactory());
         $this->assertEquals(array(
             'host' => 'ssl_host',
             'port' => 123,
@@ -71,7 +71,7 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
         $definition = $container->getDefinition('old_sound_rabbit_mq.connection.lazy_connection');
         $this->assertTrue($container->has('old_sound_rabbit_mq.connection_factory.lazy_connection'));
         $factory = $container->getDefinition('old_sound_rabbit_mq.connection_factory.lazy_connection');
-        $this->assertEquals('old_sound_rabbit_mq.connection_factory.lazy_connection', $definition->getFactoryService());
+        $this->assertEquals(array('old_sound_rabbit_mq.connection_factory.lazy_connection', 'createConnection'), $definition->getFactory());
         $this->assertEquals(array(
             'host' => 'lazy_host',
             'port' => 456,
@@ -96,7 +96,7 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
         $definition = $container->getDefinition('old_sound_rabbit_mq.connection.default');
         $this->assertTrue($container->has('old_sound_rabbit_mq.connection_factory.default'));
         $factory = $container->getDefinition('old_sound_rabbit_mq.connection_factory.default');
-        $this->assertEquals('old_sound_rabbit_mq.connection_factory.default', $definition->getFactoryService());
+        $this->assertEquals(array('old_sound_rabbit_mq.connection_factory.default', 'createConnection'), $definition->getFactory());
         $this->assertEquals(array(
             'host' => 'localhost',
             'port' => 5672,


### PR DESCRIPTION
... version 2.6

Fixes the deprecated notices while maintaining BC.