### PR TITLE
Allow consumer without exchange options

### DIFF
--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -144,6 +144,9 @@ class OldSoundRabbitMqExtension extends Extension
             //this consumer doesn't define a queue, create a temporary queue
             if (!isset($consumer['queue_options'])) {
                 $consumer['queue_options']['name'] = '';
+                $consumer['queue_options']['durable'] = false;
+                $consumer['queue_options']['exclusive'] = true;
+                $consumer['queue_options']['auto_delete'] = true;
             }
             $definition->addMethodCall('setQueueOptions', array($this->normalizeArgumentKeys($consumer['queue_options'])));
             $definition->addMethodCall('setCallback', array(array(new Reference($consumer['callback']), 'execute')));

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -141,9 +141,9 @@ class OldSoundRabbitMqExtension extends Extension
                 $consumer['exchange_options']['declare'] = false;
             }
             $definition->addMethodCall('setExchangeOptions', array($this->normalizeArgumentKeys($consumer['exchange_options'])));
-            //this consumer doesn't define a queue
+            //this consumer doesn't define a queue, create a temporary queue
             if (!isset($consumer['queue_options'])) {
-                $consumer['queue_options']['name'] = null;
+                $consumer['queue_options']['name'] = '';
             }
             $definition->addMethodCall('setQueueOptions', array($this->normalizeArgumentKeys($consumer['queue_options'])));
             $definition->addMethodCall('setCallback', array(array(new Reference($consumer['callback']), 'execute')));

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -131,12 +131,22 @@ class OldSoundRabbitMqExtension extends Extension
     {
         foreach ($this->config['consumers'] as $key => $consumer) {
             $definition = new Definition('%old_sound_rabbit_mq.consumer.class%');
-            $definition
-                ->addTag('old_sound_rabbit_mq.base_amqp')
-                ->addTag('old_sound_rabbit_mq.consumer')
-                ->addMethodCall('setExchangeOptions', array($this->normalizeArgumentKeys($consumer['exchange_options'])))
-                ->addMethodCall('setQueueOptions', array($this->normalizeArgumentKeys($consumer['queue_options'])))
-                ->addMethodCall('setCallback', array(array(new Reference($consumer['callback']), 'execute')));
+            $definition->addTag('old_sound_rabbit_mq.base_amqp');
+            $definition->addTag('old_sound_rabbit_mq.consumer');
+            //this consumer doesn't define an exchange -> using AMQP Default
+            if (!isset($consumer['exchange_options'])) {
+                $consumer['exchange_options']['name'] = '';
+                $consumer['exchange_options']['type'] = 'direct';
+                $consumer['exchange_options']['passive'] = true;
+                $consumer['exchange_options']['declare'] = false;
+            }
+            $definition->addMethodCall('setExchangeOptions', array($this->normalizeArgumentKeys($consumer['exchange_options'])));
+            //this consumer doesn't define a queue
+            if (!isset($consumer['queue_options'])) {
+                $consumer['queue_options']['name'] = null;
+            }
+            $definition->addMethodCall('setQueueOptions', array($this->normalizeArgumentKeys($consumer['queue_options'])));
+            $definition->addMethodCall('setCallback', array(array(new Reference($consumer['callback']), 'execute')));
 
             if (array_key_exists('qos_options', $consumer)) {
                 $definition->addMethodCall('setQosOptions', array(

--- a/RabbitMq/BaseAmqp.php
+++ b/RabbitMq/BaseAmqp.php
@@ -162,7 +162,7 @@ abstract class BaseAmqp
                 foreach ($this->queueOptions['routing_keys'] as $routingKey) {
                     $this->getChannel()->queue_bind($queueName, $this->exchangeOptions['name'], $routingKey);
                 }
-            } else {
+            } elseif ('' != $this->exchangeOptions['name']) {
                 $this->getChannel()->queue_bind($queueName, $this->exchangeOptions['name'], $this->routingKey);
             }
 

--- a/RabbitMq/MultipleConsumer.php
+++ b/RabbitMq/MultipleConsumer.php
@@ -70,7 +70,7 @@ class MultipleConsumer extends Consumer
                 foreach ($options['routing_keys'] as $routingKey) {
                     $this->getChannel()->queue_bind($queueName, $this->exchangeOptions['name'], $routingKey);
                 }
-            } else {
+            } elseif ('' != $this->exchangeOptions['name']) {
                 $this->getChannel()->queue_bind($queueName, $this->exchangeOptions['name'], $this->routingKey);
             }
         }


### PR DESCRIPTION
I modified consumer configuration to allow consumers without exchange options

for example : 

```yaml
    producers:
        hello:
            connection:       default
    consumers:
        hello:
            connection:       default
            exchange_options: { name: 'amq.direct', type: direct }
            queue_options:    { name: 'hello' }
            callback:         hello_consumer
```

Can be writen like this : 
```yaml
    producers:
        hello:
            connection:       default
    consumers:
        hello:
            connection:       default
            queue_options:    { name: 'hello' }
            callback:         hello_consumer
```

In my case, the hello producer uses default exchange and direct queuing and the consumer exchange is useless