### PR TITLE
added rabbitmq:delete command, used for deleting a consumer's queue

### DIFF
--- a/Command/DeleteCommand.php
+++ b/Command/DeleteCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Command to delete a queue
+ */
+class DeleteCommand extends ConsumerCommand
+{
+    protected function configure()
+    {
+        $this->addArgument('name', InputArgument::REQUIRED, 'Consumer Name')
+             ->setDescription('Delete a consumer\'s queue')
+             ->addOption('no-confirmation', null, InputOption::VALUE_NONE, 'Whether it must be confirmed before deleting');
+
+        $this->setName('rabbitmq:delete');
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $noConfirmation = (bool) $input->getOption('no-confirmation');
+
+        if (!$noConfirmation && $input->isInteractive()) {
+            $confirmation = $this->getHelper('dialog')->askConfirmation($output, sprintf('<question>Are you sure you wish to delete "%s" consumer\'s queue?(y/n)</question>', $input->getArgument('name')), false);
+            if (!$confirmation) {
+                $output->writeln('<error>Deletion cancelled!</error>');
+
+                return 1;
+            }
+        }
+
+        $this->consumer = $this->getContainer()
+            ->get(sprintf($this->getConsumerService(), $input->getArgument('name')));
+        $this->consumer->delete();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -271,6 +271,12 @@ If you want to remove all the messages awaiting in a queue, you can execute this
 $ ./app/console rabbitmq:purge --no-confirmation upload_picture
 ```
 
+For deleting the consumer's queue completely use this command:
+
+```bash
+$ ./app/console rabbitmq:delete --no-confirmation upload_picture
+```
+
 #### Idle timeout ####
 
 If you need to set a timeout when there are no messages from your queue during a period of time, you can set the `idle_timeout` in seconds:

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ If you want to remove all the messages awaiting in a queue, you can execute this
 $ ./app/console rabbitmq:purge --no-confirmation upload_picture
 ```
 
-For deleting the consumer's queue completely use this command:
+For deleting the consumer's queue, use this command:
 
 ```bash
 $ ./app/console rabbitmq:delete --no-confirmation upload_picture

--- a/RabbitMq/Consumer.php
+++ b/RabbitMq/Consumer.php
@@ -56,6 +56,14 @@ class Consumer extends BaseConsumer
     {
         $this->getChannel()->queue_purge($this->queueOptions['name'], true);
     }
+    
+    /**
+     * Delete the queue
+     */
+    public function delete()
+    {
+        $this->getChannel()->queue_delete($this->queueOptions['name'], true);
+    }
 
     public function processMessage(AMQPMessage $msg)
     {


### PR DESCRIPTION
Added rabbitmq:delete command used for removing a consumer's queue.
#265 