### PR TITLE
Removed reliance on deprecated class

### DIFF
--- a/RabbitMq/BaseAmqp.php
+++ b/RabbitMq/BaseAmqp.php
@@ -2,7 +2,7 @@
 
 namespace OldSound\RabbitMqBundle\RabbitMq;
 use PhpAmqpLib\Channel\AMQPChannel;
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AbstractConnection;
 use PhpAmqpLib\Connection\AMQPLazyConnection;
 
 abstract class BaseAmqp
@@ -39,11 +39,11 @@ abstract class BaseAmqp
     );
 
     /**
-     * @param AMQPConnection   $conn
+     * @param AbstractConnection   $conn
      * @param AMQPChannel|null $ch
      * @param null             $consumerTag
      */
-    public function __construct(AMQPConnection $conn, AMQPChannel $ch = null, $consumerTag = null)
+    public function __construct(AbstractConnection $conn, AMQPChannel $ch = null, $consumerTag = null)
     {
         $this->conn = $conn;
         $this->ch = $ch;


### PR DESCRIPTION
Since Aug 5, 2015 AMQPLazyConnection does not extend AMQPConnection anymore in php-amqplib (https://github.com/videlalvaro/php-amqplib/commit/26ef3810a68ee60a976b0ccfb64a2bd574e66908). AbstractConnection exist since 14 Feb 2012, so I do not expect any BC problems.