### PR TITLE
Correct exchange name in RPC example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ rpc_servers:
         connection: default
         callback:   random_int_server
         qos_options: {prefetch_size: 0, prefetch_count: 1, global: false}
-        exchange_options: {name: exchange, type: topic}
+        exchange_options: {name: random_int, type: topic}
         queue_options: {name: random_int_queue, durable: false, auto_delete: true}
         serializer: json_encode
 ```


### PR DESCRIPTION
The first RPC example does not work without changing the exchange name of the RPC server.