### PR TITLE
BaseAMQP not compatible with the latest php-amqp library

### DIFF
--- a/RabbitMq/BaseAmqp.php
+++ b/RabbitMq/BaseAmqp.php
@@ -2,8 +2,8 @@
 
 namespace OldSound\RabbitMqBundle\RabbitMq;
 use PhpAmqpLib\Channel\AMQPChannel;
-use PhpAmqpLib\Connection\AMQPConnection;
 use PhpAmqpLib\Connection\AMQPLazyConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 abstract class BaseAmqp
 {
@@ -39,11 +39,11 @@ abstract class BaseAmqp
     );
 
     /**
-     * @param AMQPConnection   $conn
-     * @param AMQPChannel|null $ch
-     * @param null             $consumerTag
+     * @param AMQPStreamConnection $conn
+     * @param AMQPChannel|null     $ch
+     * @param null                 $consumerTag
      */
-    public function __construct(AMQPConnection $conn, AMQPChannel $ch = null, $consumerTag = null)
+    public function __construct(AMQPStreamConnection $conn, AMQPChannel $ch = null, $consumerTag = null)
     {
         $this->conn = $conn;
         $this->ch = $ch;


### PR DESCRIPTION
I am getting this error

```
[Symfony\Component\Debug\Exception\ContextErrorException]                                                                                                                                                                                                                                                                 
  Catchable Fatal Error: Argument 1 passed to OldSound\RabbitMqBundle\RabbitMq\BaseAmqp::__construct() must be an instance of PhpAmqpLib\Connection\AMQPConnection, instance of PhpAmqpLib\Connection\AMQPLazyConnection given, called in /vagrant/app/cache/dev/appDevDebugProjectContainer.php on line 13690 and defined  
```

It is safe change cuz `AMQPConnection` extends `AMQPStreamConnection` class.