### PR TITLE
Update README with notice about heartbeats

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ configuration to avoid unnecessary connections to your message broker in every r
 It's extremely recommended to use lazy connections because performance reasons, nevertheless lazy option is disabled
 by default to avoid possible breaks in applications already using this bundle.
 
+### Import notice - Heartbeats ###
+
+It's a good idea to set the ```read_write_timeout``` to 2x the heartbeat so your socket will be open. If you don't do this, or use a different multiplier, there's a risk the __consumer__ socket will timeout.
+
 ## Producers, Consumers, What? ##
 
 In a messaging application, the process sending messages to the broker is called __producer__ while the process receiving those messages is called __consumer__. In your application you will have several of them that you can list under their respective entries in the configuration.


### PR DESCRIPTION
The original notice was added to the pull request that added heartbeat support, but it wasn't added to the documentation. This made it a rather annoying caveat, specially on platforms such as AWS, which need the heartbeat to work.

See https://github.com/videlalvaro/php-amqplib/pull/191 for the original notice.